### PR TITLE
remote: accept 404 errors

### DIFF
--- a/lieer/remote.py
+++ b/lieer/remote.py
@@ -147,14 +147,14 @@ class Remote:
     def _cb (rid, resp, excep):
       nonlocal j
       if excep is not None:
-        raise Remote.BatchException(excep)
-        # if type(excep) is googleapiclient.errors.HttpError and excep.resp.status == 404:
-        #   # message could not be found this is probably a deleted message, spam or draft
-        #   # message since these are not included in the messages.get() query by default.
-        #   j += 1
-        #   return
-        # else:
-        #   raise Remote.BatchException(excep)
+        if type(excep) is googleapiclient.errors.HttpError and excep.resp.status == 404:
+          # message could not be found this is probably a deleted message, spam or draft
+          # message since these are not included in the messages.get() query by default.
+          print ("remote: could not find remote message: %s!" % mids[j])
+          j += 1
+          return
+        else:
+          raise Remote.BatchException(excep)
       else:
         j += 1
 


### PR DESCRIPTION
Not sure how this can happen, so reluctant to accept 404s.

http://stackoverflow.com/questions/42646735/message-returned-with-history-list-cannot-be-found-with-messages-get