### PR TITLE
Handle FileNotEmailError.

### DIFF
--- a/lieer/local.py
+++ b/lieer/local.py
@@ -295,7 +295,11 @@ class Local:
       if self.dry_run:
         print ("(dry-run) adding message: %s: %s, with tags: %s" % (mid, fname, str(labels)))
       else:
-        (nmsg, stat) = db.add_message (fname, True)
+        try:
+          (nmsg, stat) = db.add_message (fname, True)
+        except notmuch.errors.FileNotEmailError:
+          print('%s is not an email' % fname)
+          return True
         nmsg.freeze ()
 
         # adding initial tags


### PR DESCRIPTION
looks like my gmail account has a corrupt message. The entire file is:

--------------------------------------------------------------
Delivered-To: rafael.espindola@gmail.com
Received: by 10.90.88.7 with SMTP id l7cs647623agb;
        Thu, 17 May 2007 03:03:08 -0700 (PDT)
Received: by 10.67.50.7 with SMTP id c7mr144218ugk.1179396188365;
        Thu, 17 May 2007 03:03:08 -0700 (PDT)
Return-Path: <dhatch@ilt.fhg.de>
Received: from faurelayrz-1.rrze.uni-erlangen.de ([58.119.45.48])
        by mx.google.com with ESMTP id 5si126923ugc.2007.05.17.03.02.52;
        Thu, 17 May 2007 03:03:08 -0700 (PDT)
Received-SPF: neutral (google.com: 58.119.45.48 is neither permitted nor denied by best guess record for domain of dhatch@ilt.fhg.de)
Message-Id: <464c285c.6ebaed29.06c7.2018SMTPIN_ADDED@mx.google.com>
06/03/2007 (13: 53 GMT  +03:00)
 1.0
Content-Type: text/html
Date: %CURRENT_DATE_TIME

%MESSAGE_BODY
----------------------------------------------------------

This patch just logs these messages and keeps going. This is similar
to what "notmuch new" does.