### PR TITLE
ship oauth2 client_id and client_secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,11 @@ warranties.**
 
 # usage
 
-this assumes your root mail folder is in `~/.mail`, all `gmailieer` commands
-should be run from the `gmailieer` storage unless otherwise specified.
+This assumes your root mail folder is in `~/.mail`, all commands
+should be run from the local mail repository unless otherwise specified.
 
-1. get an [api key](https://console.developers.google.com/flows/enableapi?apiid=gmail) for a CLI application and store the client_secret.json file
-   somewhere safe, this is needed when authenticating (`auth -c`).
 
-2. make a directory for the gmailieer storage and state files
+1. Make a directory for the gmailieer storage and state files
 
 ```sh
 $ cd    ~/.mail
@@ -34,22 +32,24 @@ $ mkdir account.gmail
 $ cd    account.gmail/
 ```
 
-3. ignore the `.json` files in notmuch:
+2. Ignore the `.json` files in notmuch:
 
 ```
 [new]
 ignore=*.json;
 ```
 
-4. initialize the mail storage:
+3. Initialize the mail storage:
 
 ```sh
-$ gmi init -c path/to/client_secrets.json your.email@gmail.com
+$ gmi init your.email@gmail.com
 ```
 
-`gmi init` will now open your browser and request some access to your e-mail. the access token is stored in `.credentials.gmailieer.json` in the local mail repository. you can stow `client_secrets.json` somewhere safe, it is not generally needed anymore. if this somehow fails you can complete authorization by using `gmi auth`.
+`gmi init` will now open your browser and request limited access to your e-mail.
 
-5. you're now set up, and you can do the initial pull.
+> The access token is stored in `.credentials.gmailieer.json` in the local mail repository. If you wish, you can specify [your own api key](#using-your-own-api-key) that should be used.
+
+4. You're now set up, and you can do the initial pull.
 
 > Use `gmi -h` or `gmi command -h` to get more usage information.
 
@@ -86,4 +86,11 @@ with the remote in `push` will not be pushed. After the next `pull` has been
 run the conflicts should be resolved, overwriting the local changes with the
 remote changes. You can force the local changes to overwrite the remote changes
 by using `push -f`.
+
+## using your own API key
+
+gmailieer ships with an API key that is shared openly, this key shares API quota, but [cannot be used to access data](https://github.com/gauteh/gmailieer/pull/9) unless access is gained to your private `access_token` or `refresh_token`.
+
+You can get an [api key](https://console.developers.google.com/flows/enableapi?apiid=gmail) for a CLI application to use for yourself. Store the `client_secret.json` file somewhere safe and specify it to `gmi auth -c`. You can do this on a repository that is already initialized.
+
 

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -24,8 +24,8 @@ class Gmailieer:
     self.parser = parser
 
     common = argparse.ArgumentParser (add_help = False)
-    common.add_argument ('-c', '--credentials', type = str, default = 'client_secret.json',
-        help = 'credentials file for google api (default: client_secret.json)')
+    common.add_argument ('-c', '--credentials', type = str, default = None,
+        help = 'optional credentials file for google api')
 
     subparsers = parser.add_subparsers (help = 'actions', dest = 'action')
     subparsers.required = True

--- a/lieer/remote.py
+++ b/lieer/remote.py
@@ -14,12 +14,12 @@ class Remote:
   authorized         = False
 
   OAUTH2_CLIENT_SECRET = {
-       "client_id":"XXXX",
+       "client_id":"753933720722-ju82fu305lii0v9rdo6mf9hj40l5juv0.apps.googleusercontent.com",
         "project_id":"capable-pixel-160614",
         "auth_uri":"https://accounts.google.com/o/oauth2/auth",
         "token_uri":"https://accounts.google.com/o/oauth2/token",
         "auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs",
-        "client_secret":"YYYY",
+        "client_secret":"8oudEG0Tvb7YI2V0ykp2Pzz9",
         "redirect_uris":["urn:ietf:wg:oauth:2.0:oob", "http://localhost"]
     }
 


### PR DESCRIPTION
this way a user does not need to get his own API key, though it might be
safer. as far as I can see, there should be no way to access mail
without getting the access and refresh tokens with the users consent.

according to: https://developers.google.com/identity/protocols/OAuth2#installed client_id and client_secret is not so-secret in these types of applications, but who know how this works..

a malicious attacker might steal the id and secret and use it in his own
project, this might use the app quota, but should not be able to access
user account.

some more discussion:

* http://stackoverflow.com/questions/25957027/oauth-2-installed-application-client-secret-considerationsgoogle-api/43061998#43061998
* http://stackoverflow.com/questions/19615372/client-secret-in-oauth-2-0?rq=1