### PR TITLE
remote: sync messages in TRASH or SPAM as well (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,17 @@ account and store them locally in a maildir with the labels synchronized with a
 [notmuch](https://notmuchmail.org/) database. The changes to tags in the
 notmuch database may be pushed back remotely to your GMail account.
 
-It will not and can not:
-* Add or delete messages on your remote account
-* Modify messages other than their labels
-
 ## disclaimer
 
-This does not modify or delete your email remotely, but it can modify the
-message labels remotely. So those may be lost if all goes wrong. Also, whether
-you will actually get all your email is not proven. **In short: No
-warranties.**
+Gmailieer will not and can not:
+
+* Add or delete messages on your remote account, except `trash` or `spam` messages (and those will eventually be [deleted](https://support.google.com/mail/answer/7401?co=GENIE.Platform%3DDesktop&hl=en))
+* Modify messages other than their labels
+
+So `trash`'ed or `spam`'ed messages (or if somehow these tags get added to all
+your messages) may be lost, as well as messages labels may be lost if all goes
+wrong. Also, whether you will actually get all your email is not proven. **In
+short: No warranties.**
 
 ## requirements
 
@@ -109,8 +110,8 @@ You can get an [api key](https://console.developers.google.com/flows/enableapi?a
 
 # caveats
 
-The GMail API does not let you sync `muted` messages. Until the [Google
+* The GMail API does not let you sync `muted` messages. Until [this Google
 bug](https://issuetracker.google.com/issues/36759067) is fixed, the `mute` and `muted` tags are not synchronized with the remote.
 
-Only one of the tags `inbox`, `spam`, and `trash` may be added to an email. For
+* Only one of the tags `inbox`, `spam`, and `trash` may be added to an email. For
 the time being, `trash` will be prefered over `spam`, and `spam` over inbox.

--- a/lieer/remote.py
+++ b/lieer/remote.py
@@ -63,7 +63,7 @@ class Remote:
   # query to use
   query = '-in:chats'
 
-  not_sync = set (['CHAT', 'SPAM', 'TRASH'])
+  not_sync = set (['CHAT'])
 
   # used to indicate whether all messages that should be updated where updated
   all_updated = True
@@ -192,7 +192,7 @@ class Remote:
     """
 
     self.__wait_delay__ ()
-    results = self.service.users ().messages ().list (userId = self.account, q = self.query, maxResults = limit).execute ()
+    results = self.service.users ().messages ().list (userId = self.account, q = self.query, maxResults = limit, includeSpamTrash = True).execute ()
 
     if 'messages' in results:
       self.__request_done__ (True)
@@ -202,7 +202,7 @@ class Remote:
 
     while 'nextPageToken' in results:
       pt = results['nextPageToken']
-      _results = self.service.users ().messages ().list (userId = self.account, pageToken = pt, q = self.query, maxResults = limit).execute ()
+      _results = self.service.users ().messages ().list (userId = self.account, pageToken = pt, q = self.query, maxResults = limit, includeSpamTrash = True).execute ()
 
       if 'messages' in _results:
         self.__request_done__ (True)


### PR DESCRIPTION
Please test #35 

You need to do a full sync `gmi pull -f` to get these, consider trying out with dry-run first. Note that messages in GMail trash are deleted after 30 days, so if you add the trash/spam tag to local messages this may cause messages to be deleted.