### PR TITLE
Workaround #48

### DIFF
--- a/lieer/local.py
+++ b/lieer/local.py
@@ -35,6 +35,7 @@ class Local:
                         'replied',
                         'muted',
                         'mute',
+                        'unknown'
                         ])
 
   class RepositoryException (Exception):
@@ -351,9 +352,10 @@ class Local:
     labels = m.get('labelIds', [])
 
     # translate labels. Remote.get_labels () must have been called first
-    labels = [self.gmailieer.remote.labels[l] for l in labels]
-
-    labels = set(labels)
+    newLabels = []
+    for l in labels:
+        newLabels.append(self.gmailieer.remote.labels.get(l, "unknown"))
+    labels = set(newLabels)
 
     # remove ignored labels
     labels = list(labels - self.gmailieer.remote.ignore_labels)

--- a/lieer/remote.py
+++ b/lieer/remote.py
@@ -58,7 +58,8 @@ class Remote:
                         'CATEGORY_SOCIAL',
                         'CATEGORY_PROMOTIONS',
                         'CATEGORY_UPDATES',
-                        'CATEGORY_FORUMS'
+                        'CATEGORY_FORUMS',
+                        'unknown'
                       ])
   # query to use
   query = '-in:chats'
@@ -430,10 +431,11 @@ class Remote:
       return None
 
     labels = gmsg.get('labelIds', [])
-    labels = [self.labels[l] for l in labels]
-
+    newLabels = []
+    for l in labels:
+        newLabels.append(self.labels.get(l, "unknown"))
     # remove ignored labels
-    labels = set (labels)
+    labels = set(newLabels)
     labels = labels - self.ignore_labels
 
     # translate to notmuch tags


### PR DESCRIPTION
This adds a notmuch "unknown" tag whenever a label id which cannot be found
in the list of available label ids is retrieved from a message. Notice the
"unknown" tag is never synchronized.