### PR TITLE
Missing gmail label

### DIFF
--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -127,6 +127,8 @@ class Gmailieer:
     parser_set.add_argument ('--replace-slash-with-dot', action = 'store_true', default = False,
         help = 'This will replace \'/\' with \'.\' in gmail labels (make sure you realize the implications)')
 
+    parser_set.add_argument ('--no-replace-slash-with-dot', action = 'store_true', default = False)
+
     parser_set.set_defaults (func = self.set)
 
 
@@ -610,6 +612,9 @@ class Gmailieer:
 
     if args.replace_slash_with_dot:
       self.local.state.set_replace_slash_with_dot (args.replace_slash_with_dot)
+
+    if args.no_replace_slash_with_dot:
+      self.local.state.set_replace_slash_with_dot (not args.no_replace_slash_with_dot)
 
     print ("Repository info:")
     print ("Account ...........: %s" % self.local.state.account)

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -129,6 +129,11 @@ class Gmailieer:
 
     parser_set.add_argument ('--no-replace-slash-with-dot', action = 'store_true', default = False)
 
+    parser_set.add_argument ('--drop-non-existing-labels', action = 'store_true', default = False,
+        help = 'Allow missing labels on the GMail side to be dropped (see https://github.com/gauteh/gmailieer/issues/48)')
+
+    parser_set.add_argument ('--no-drop-non-existing-labels', action = 'store_true', default = False)
+
     parser_set.set_defaults (func = self.set)
 
 
@@ -616,11 +621,18 @@ class Gmailieer:
     if args.no_replace_slash_with_dot:
       self.local.state.set_replace_slash_with_dot (not args.no_replace_slash_with_dot)
 
+    if args.drop_non_existing_labels:
+      self.local.state.set_drop_non_existing_label (args.drop_non_existing_labels)
+
+    if args.no_drop_non_existing_labels:
+      self.local.state.set_drop_non_existing_label (not args.no_drop_non_existing_labels)
+
     print ("Repository info:")
     print ("Account ...........: %s" % self.local.state.account)
     print ("Timeout ...........: %f" % self.local.state.timeout)
     print ("historyId .........: %d" % self.local.state.last_historyId)
     print ("lastmod ...........: %d" % self.local.state.lastmod)
+    print ("drop non labels ...:", self.local.state.drop_non_existing_label)
     print ("replace . with / ..:", self.local.state.replace_slash_with_dot)
 
 

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -35,6 +35,7 @@ class Local:
                         'replied',
                         'muted',
                         'mute',
+                        'unknown'
                         ])
 
   class RepositoryException (Exception):
@@ -351,9 +352,10 @@ class Local:
     labels = m.get('labelIds', [])
 
     # translate labels. Remote.get_labels () must have been called first
-    labels = [self.gmailieer.remote.labels[l] for l in labels]
-
-    labels = set(labels)
+    newLabels = []
+    for l in labels:
+        newLabels.append(self.gmailieer.remote.labels.get(l, "unknown"))
+    labels = set(newLabels)
 
     # remove ignored labels
     labels = list(labels - self.gmailieer.remote.ignore_labels)

--- a/lieer/remote.py
+++ b/lieer/remote.py
@@ -58,7 +58,8 @@ class Remote:
                         'CATEGORY_SOCIAL',
                         'CATEGORY_PROMOTIONS',
                         'CATEGORY_UPDATES',
-                        'CATEGORY_FORUMS'
+                        'CATEGORY_FORUMS',
+                        'unknown'
                       ])
   # query to use
   query = '-in:chats'
@@ -430,10 +431,11 @@ class Remote:
       return None
 
     labels = gmsg.get('labelIds', [])
-    labels = [self.labels[l] for l in labels]
-
+    newLabels = []
+    for l in labels:
+        newLabels.append(self.labels.get(l, "unknown"))
     # remove ignored labels
-    labels = set (labels)
+    labels = set(newLabels)
     labels = labels - self.ignore_labels
 
     # translate to notmuch tags


### PR DESCRIPTION
Alternative to #49 (fixing #48)

Just drop the label if it doesn't exist on the remote side. Must be enabled with:

```
$ gmi set --drop-non-existing-labels
```

by the user.