### PR TITLE
local: ignore the `todo` tag, seems to be reserverd by GMail

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,5 +110,7 @@ You can get an [api key](https://console.developers.google.com/flows/enableapi?a
 * The GMail API does not let you sync `muted` messages. Until [this Google
 bug](https://issuetracker.google.com/issues/36759067) is fixed, the `mute` and `muted` tags are not synchronized with the remote.
 
+* The `todo` label seems to be reserved and will be ignored.
+
 * Only one of the tags `inbox`, `spam`, and `trash` may be added to an email. For
 the time being, `trash` will be prefered over `spam`, and `spam` over inbox.

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -35,6 +35,7 @@ class Local:
                         'replied',
                         'muted',
                         'mute',
+                        'todo',
                         ])
 
   class RepositoryException (Exception):


### PR DESCRIPTION
#52 