### PR TITLE
remote: fetch messages using IMAP

### DIFF
--- a/lieer/gimap.py
+++ b/lieer/gimap.py
@@ -1,0 +1,73 @@
+import imaplib
+import base64
+
+class Gimap:
+  """
+  * https://github.com/google/gmail-oauth2-tools/blob/master/python/oauth2.py#L255
+  * https://developers.google.com/gmail/imap/imap-extensions
+  """
+
+  remote = None
+  conn   = None
+
+  class GimapException (Exception):
+    pass
+
+  def __init__(self, remote):
+    self.remote = remote
+
+  def generate_xoauth (self):
+    """
+    user is email
+    """
+
+    username = self.remote.gmailieer.local.state.account
+
+    if username == 'me':
+      raise GimapException ("account must be specified, cannot use 'me'")
+
+    access_token = self.remote.credentials.access_token
+
+    auth_string = 'user=%s\1auth=Bearer %s\1\1' % (username, access_token)
+    return auth_string
+
+  def connect (self):
+    auth_str = self.generate_xoauth ()
+
+    self.conn = imaplib.IMAP4_SSL ('imap.gmail.com')
+    # self.conn.debug = 4
+    self.conn.authenticate ('XOAUTH2', lambda x: auth_str)
+
+  def disconnect (self):
+    if self.conn is not None:
+      self.conn.close ()
+
+  def get_messages (self, messages, msg_cb):
+    # get name of all e-mail folder
+    typ, lst = self.conn.list()
+
+    for l in lst:
+      if b'\All' in l:
+        ri = l.rfind (b'"[Gmail]/')
+        alle = l[ri:]
+
+    self.conn.select(alle)
+
+    for m in messages:
+      # get UID
+      typ, msgnums = self.conn.search(None, 'X-GM-MSGID %d' % int(m, 16))
+
+      if typ != 'OK':
+        raise GimapException ('Failed to get GM-MSGID: %s' % m)
+
+      # fetch message
+      for num in msgnums[0].split():
+        typ, data = self.conn.fetch (num, '(RFC822)')
+
+        if typ != 'OK':
+          raise GimapException ('Failed to fetch message GM-MSGID: %s' % m)
+
+        msg_cb (data[0][1], m)
+
+
+

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -315,19 +315,26 @@ class Local:
       self.files.remove (ffname)
       self.gids.pop (gid)
 
-  def store (self, m, db):
+  def store (self, m, db, imap = False, _gid = None):
     """
     Store message in local store
     """
 
-    gid     = m['id']
-    msg_str = base64.urlsafe_b64decode(m['raw'].encode ('ASCII'))
+    if imap:
+      gid = _gid
+      msg_str = m
+    else:
+      gid     = m['id']
+      msg_str = base64.urlsafe_b64decode(m['raw'].encode ('ASCII'))
 
     # messages from GMail have windows line endings
     if os.linesep == '\n':
       msg_str = msg_str.replace (b'\r\n', b'\n')
 
-    labels  = m.get('labelIds', [])
+    if imap:
+      labels = []
+    else:
+      labels  = m.get('labelIds', [])
 
     bname = self.__make_maildir_name__(gid, labels)
 
@@ -351,7 +358,8 @@ class Local:
       os.rename (tmp_p, p)
 
     # add to notmuch
-    self.update_tags (m, p, db)
+    if not imap:
+      self.update_tags (m, p, db)
 
   def update_tags (self, m, fname, db):
     # make sure notmuch tags reflect gmail labels

--- a/lieer/remote.py
+++ b/lieer/remote.py
@@ -7,9 +7,10 @@ from oauth2client import client
 from oauth2client import tools
 from oauth2client.file import Storage
 from pathlib import Path
+from .gimap import Gimap
 
 class Remote:
-  SCOPES = 'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.labels https://www.googleapis.com/auth/gmail.modify'
+  SCOPES = 'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.labels https://www.googleapis.com/auth/gmail.modify https://mail.google.com/'
   APPLICATION_NAME   = 'Gmailieer'
   CLIENT_SECRET_FILE = None
   authorized         = False
@@ -132,6 +133,9 @@ class Remote:
         raise Remote.GenericException ("cannot increase delay more to more than maximum %d s" % self.MAX_DELAY)
 
 
+  @__require_auth__
+  def setup_imap (self):
+    self.imap = Gimap (self)
 
   @__require_auth__
   def get_labels (self):


### PR DESCRIPTION
__Not very well tested!__

Use IMAP to fetch message content.

This requires:
* fetch message list
* for each message
  - fetch IMAP UID for GMail msgid
  - fetch message content
* fetch metadata for all messages in batch requests (to get labels)

Requires extended scope (access rights). Try with `gmi pull --imap`.