### PR TITLE
Custom ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ mkdir account.gmail
 $ cd    account.gmail/
 ```
 
-2. Ignore the `.json` files in notmuch and use `new` for [new tags](https://notmuchmail.org/initial_tagging/). Set up a `post-new` hook as [described](https://notmuchmail.org/initial_tagging/) to process mail and remove the `new` tag afterwards. The `new` tag is not synchronized with the remote by `gmailieer`.
+2. Ignore the `.json` files in notmuch. Any tags listed in `new.tags` will be added to newly pulled messages. Process tags on new messages directly after running gmi, or run `notmuch new` to trigger the `post-new` hook for [initial tagging](https://notmuchmail.org/initial_tagging/). Remove the `new` tag afterwards. You can prevent custom tags from being pushed to the remote by using e.g. `gmi set --ignore-tags new`.
 
 ```
 [new]

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -137,6 +137,9 @@ class Gmailieer:
 
     parser_set.add_argument ('--no-drop-non-existing-labels', action = 'store_true', default = False)
 
+    parser_set.add_argument ('--ignore-tags', type = str,
+        default = None, help = 'Set custom tags to ignore (comma-separated)')
+
     parser_set.set_defaults (func = self.set)
 
 
@@ -648,6 +651,9 @@ class Gmailieer:
     if args.no_drop_non_existing_labels:
       self.local.state.set_drop_non_existing_label (not args.no_drop_non_existing_labels)
 
+    if args.ignore_tags is not None:
+      self.local.state.set_ignore_tags (args.ignore_tags)
+
     print ("Repository info:")
     print ("Account ...........: %s" % self.local.state.account)
     print ("Timeout ...........: %f" % self.local.state.timeout)
@@ -655,6 +661,7 @@ class Gmailieer:
     print ("lastmod ...........: %d" % self.local.state.lastmod)
     print ("drop non labels ...:", self.local.state.drop_non_existing_label)
     print ("replace . with / ..:", self.local.state.replace_slash_with_dot)
+    print ("ignore tags .......:", self.local.state.ignore_tags)
 
 
 

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -30,7 +30,6 @@ class Local:
                         'attachment',
                         'encrypted',
                         'signed',
-                        'new',
                         'passed',
                         'replied',
                         'muted',

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -73,6 +73,7 @@ class Local:
       self.account = self.json.get ('account', 'me')
       self.timeout = self.json.get ('timeout', 0)
       self.drop_non_existing_label = self.json.get ('drop_non_existing_label', False)
+      self.ignore_tags = set(self.json.get ('ignore_tags', []))
 
     def write (self):
       self.json = {}
@@ -83,6 +84,7 @@ class Local:
       self.json['account'] = self.account
       self.json['timeout'] = self.timeout
       self.json['drop_non_existing_label'] = self.drop_non_existing_label
+      self.json['ignore_tags'] = list(self.ignore_tags)
 
       if os.path.exists (self.state_f):
         shutil.copyfile (self.state_f, self.state_f + '.bak')
@@ -115,6 +117,14 @@ class Local:
       self.drop_non_existing_label = r
       self.write ()
 
+    def set_ignore_tags (self, t):
+      if len(t.strip ()) == 0:
+        self.ignore_tags = set()
+      else:
+        self.ignore_tags = set([ tt.strip () for tt in t.split(',') ])
+
+      self.write ()
+
   def __init__ (self, g):
     self.gmailieer = g
     self.wd = os.getcwd ()
@@ -139,6 +149,8 @@ class Local:
       raise Local.RepositoryException ('local repository not initialized: could not find mail dir')
 
     self.state = Local.State (self.state_f)
+
+    self.ignore_labels = self.ignore_labels | self.state.ignore_tags
 
     ## Check if we are in the notmuch db
     with notmuch.Database () as db:


### PR DESCRIPTION
Specify custom tags to be ignored when pushing:

  gmi set --ignore-tags queue,todo

Separate tags with comma. you have to specify the full list if you want
to modify. Use:

  gmi set

to see current set. You can clear the ignored tags with:

  gmi set --ignore-tags ""

the change will not work retrospectively, and you will have to manually
change something on a message for it to be pushed anew.

#80 #32 