### PR TITLE
optionally translate and unignore categories (fixes #87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ cd    account.gmail/
 All commands should be run from the local mail repository unless otherwise specified.
 
 
-2. Ignore the `.json` files in notmuch. Any tags listed in `new.tags` will be added to newly pulled messages. Process tags on new messages directly after running gmi, or run `notmuch new` to trigger the `post-new` hook for [initial tagging](https://notmuchmail.org/initial_tagging/). The `new.tags` are not ignored by default if you do not remove them, but you can prevent custom tags from being pushed to the remote by using e.g. `gmi set --ignore-tags new`.
+2. Ignore the `.json` files in notmuch. Any tags listed in `new.tags` will be added to newly pulled messages. Process tags on new messages directly after running gmi, or run `notmuch new` to trigger the `post-new` hook for [initial tagging](https://notmuchmail.org/initial_tagging/). The `new.tags` are not ignored by default if you do not remove them, but you can prevent custom tags from being pushed to the remote by using e.g. `gmi set --ignore-tags-local new`.
 
 ```
 [new]
@@ -110,7 +110,11 @@ gmailieer ships with an API key that is shared openly, this key shares API quota
 You can get an [api key](https://console.developers.google.com/flows/enableapi?apiid=gmail) for a CLI application to use for yourself. Store the `client_secret.json` file somewhere safe and specify it to `gmi auth -c`. You can do this on a repository that is already initialized.
 
 
-# caveats
+# caveats and notes
+
+* Changing ignored tags, or `replace-slash-with-dot`, after the initial sync might cause the ignored tags to be lost on either remote or local side when the messages are synced at a later time.
+
+* The category labels (the Personal/Promotions/etc tabs in your GMail inbox) are ignored by default. These can be unignored by doing: `gmi set --ignore-tags-remote ""`. Note that this setting expects [untranslated labels](https://github.com/gauteh/gmailieer/blob/master/lieer/local.py#L15).
 
 * The GMail API does not let you sync `muted` messages. Until [this Google
 bug](https://issuetracker.google.com/issues/36759067) is fixed, the `mute` and `muted` tags are not synchronized with the remote.

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -137,8 +137,11 @@ class Gmailieer:
 
     parser_set.add_argument ('--no-drop-non-existing-labels', action = 'store_true', default = False)
 
-    parser_set.add_argument ('--ignore-tags', type = str,
-        default = None, help = 'Set custom tags to ignore (comma-separated)')
+    parser_set.add_argument ('--ignore-tags-local', type = str,
+        default = None, help = 'Set custom tags to ignore when syncing from local to remote (comma-separated, after translations)')
+
+    parser_set.add_argument ('--ignore-tags-remote', type = str,
+        default = None, help = 'Set custom tags to ignore when syncing from remote to local (comma-separated, before translations)')
 
     parser_set.set_defaults (func = self.set)
 
@@ -651,8 +654,11 @@ class Gmailieer:
     if args.no_drop_non_existing_labels:
       self.local.state.set_drop_non_existing_label (not args.no_drop_non_existing_labels)
 
-    if args.ignore_tags is not None:
-      self.local.state.set_ignore_tags (args.ignore_tags)
+    if args.ignore_tags_local is not None:
+      self.local.state.set_ignore_tags (args.ignore_tags_local)
+
+    if args.ignore_tags_remote is not None:
+      self.local.state.set_ignore_remote_labels (args.ignore_tags_remote)
 
     print ("Repository info:")
     print ("Account ...........: %s" % self.local.state.account)
@@ -661,7 +667,8 @@ class Gmailieer:
     print ("lastmod ...........: %d" % self.local.state.lastmod)
     print ("drop non labels ...:", self.local.state.drop_non_existing_label)
     print ("replace . with / ..:", self.local.state.replace_slash_with_dot)
-    print ("ignore tags .......:", self.local.state.ignore_tags)
+    print ("ignore tags (local) .......:", self.local.state.ignore_tags)
+    print ("ignore labels (remote) ....:", self.local.state.ignore_remote_labels)
 
 
 

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -128,7 +128,7 @@ class Gmailieer:
         default = None, help = 'Set HTTP timeout in seconds (0 means forever or system timeout)')
 
     parser_set.add_argument ('--replace-slash-with-dot', action = 'store_true', default = False,
-        help = 'This will replace \'/\' with \'.\' in gmail labels (make sure you realize the implications)')
+        help = 'This will replace \'/\' with \'.\' in gmail labels (Important: see the manual and make sure you realize the implications)')
 
     parser_set.add_argument ('--no-replace-slash-with-dot', action = 'store_true', default = False)
 
@@ -138,10 +138,10 @@ class Gmailieer:
     parser_set.add_argument ('--no-drop-non-existing-labels', action = 'store_true', default = False)
 
     parser_set.add_argument ('--ignore-tags-local', type = str,
-        default = None, help = 'Set custom tags to ignore when syncing from local to remote (comma-separated, after translations)')
+        default = None, help = 'Set custom tags to ignore when syncing from local to remote (comma-separated, after translations). Important: see the manual.')
 
     parser_set.add_argument ('--ignore-tags-remote', type = str,
-        default = None, help = 'Set custom tags to ignore when syncing from remote to local (comma-separated, before translations)')
+        default = None, help = 'Set custom tags to ignore when syncing from remote to local (comma-separated, before translations). Important: see the manual.')
 
     parser_set.set_defaults (func = self.set)
 
@@ -660,15 +660,15 @@ class Gmailieer:
     if args.ignore_tags_remote is not None:
       self.local.state.set_ignore_remote_labels (args.ignore_tags_remote)
 
-    print ("Repository info:")
+    print ("Repository information and settings:")
     print ("Account ...........: %s" % self.local.state.account)
-    print ("Timeout ...........: %f" % self.local.state.timeout)
     print ("historyId .........: %d" % self.local.state.last_historyId)
     print ("lastmod ...........: %d" % self.local.state.lastmod)
-    print ("drop non labels ...:", self.local.state.drop_non_existing_label)
-    print ("replace . with / ..:", self.local.state.replace_slash_with_dot)
-    print ("ignore tags (local) .......:", self.local.state.ignore_tags)
-    print ("ignore labels (remote) ....:", self.local.state.ignore_remote_labels)
+    print ("Timeout ...........: %f" % self.local.state.timeout)
+    print ("Drop non existing labels...:", self.local.state.drop_non_existing_label)
+    print ("Replace . with / ..........:", self.local.state.replace_slash_with_dot)
+    print ("Ignore tags (local) .......:", self.local.state.ignore_tags)
+    print ("Ignore labels (remote) ....:", self.local.state.ignore_remote_labels)
 
 
 

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -13,6 +13,7 @@ class Local:
   loaded  = False
 
 
+  # NOTE: Update README when changing this map.
   translate_labels = {
                       'INBOX'     : 'inbox',
                       'SPAM'      : 'spam',

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import tempfile
 
 import notmuch
+from .remote import Remote
 
 class Local:
   wd      = None
@@ -21,7 +22,13 @@ class Local:
                       'IMPORTANT' : 'important',
                       'SENT'      : 'sent',
                       'DRAFT'     : 'draft',
-                      'CHAT'      : 'chat'
+                      'CHAT'      : 'chat',
+
+                      'CATEGORY_PERSONAL'     : 'personal',
+                      'CATEGORY_SOCIAL'       : 'social',
+                      'CATEGORY_PROMOTIONS'   : 'promotions',
+                      'CATEGORY_UPDATES'      : 'updates',
+                      'CATEGORY_FORUMS'       : 'forums',
                       }
 
   labels_translate = { v: k for k, v in translate_labels.items () }
@@ -56,6 +63,8 @@ class Local:
     account = None
     timeout = 0
     drop_non_existing_label = False
+    ignore_tags = None
+    ignore_remote_labels = None
 
     def __init__ (self, state_f):
       self.state_f = state_f
@@ -73,6 +82,7 @@ class Local:
       self.timeout = self.json.get ('timeout', 0)
       self.drop_non_existing_label = self.json.get ('drop_non_existing_label', False)
       self.ignore_tags = set(self.json.get ('ignore_tags', []))
+      self.ignore_remote_labels = set(self.json.get ('ignore_remote_labels', Remote.DEFAULT_IGNORE_LABELS))
 
     def write (self):
       self.json = {}
@@ -84,6 +94,7 @@ class Local:
       self.json['timeout'] = self.timeout
       self.json['drop_non_existing_label'] = self.drop_non_existing_label
       self.json['ignore_tags'] = list(self.ignore_tags)
+      self.json['ignore_remote_labels'] = list(self.ignore_remote_labels)
 
       if os.path.exists (self.state_f):
         shutil.copyfile (self.state_f, self.state_f + '.bak')
@@ -121,6 +132,14 @@ class Local:
         self.ignore_tags = set()
       else:
         self.ignore_tags = set([ tt.strip () for tt in t.split(',') ])
+
+      self.write ()
+
+    def set_ignore_remote_labels (self, t):
+      if len(t.strip ()) == 0:
+        self.ignore_remote_labels = set()
+      else:
+        self.ignore_remote_labels = set([ tt.strip () for tt in t.split(',') ])
 
       self.write ()
 

--- a/lieer/remote.py
+++ b/lieer/remote.py
@@ -34,6 +34,7 @@ class Remote:
         "redirect_uris":["urn:ietf:wg:oauth:2.0:oob", "http://localhost"]
     }
 
+  # Not used, here for documentation purposes
   special_labels = [  'INBOX',
                       'SPAM',
                       'TRASH',
@@ -54,12 +55,15 @@ class Remote:
   read_only_labels = set(['SENT', 'DRAFT'])
   read_only_tags   = set(['sent', 'draft'])
 
-  ignore_labels = set([ 'CATEGORY_PERSONAL',
-                        'CATEGORY_SOCIAL',
-                        'CATEGORY_PROMOTIONS',
-                        'CATEGORY_UPDATES',
-                        'CATEGORY_FORUMS',
-                      ])
+  DEFAULT_IGNORE_LABELS = [ 'CATEGORY_PERSONAL',
+                            'CATEGORY_SOCIAL',
+                            'CATEGORY_PROMOTIONS',
+                            'CATEGORY_UPDATES',
+                            'CATEGORY_FORUMS',
+                          ]
+
+  ignore_labels = set()
+
   # query to use
   query = '-in:chats'
 
@@ -102,6 +106,8 @@ class Remote:
     self.CLIENT_SECRET_FILE = g.credentials_file
     self.account = g.local.state.account
     self.dry_run = g.dry_run
+
+    self.ignore_labels = self.gmailieer.local.state.ignore_remote_labels
 
   def __require_auth__ (func):
     def func_wrap (self, *args, **kwargs):


### PR DESCRIPTION
The categories are optionally unignored and translated to lower-case
versions without the preceding CATEGORY_ part.

The new set option --ignore-tags-remote can be used to unignore the
labels. The --ignore-tags option has been renamed to
--ignore-tags-local.