### PR TITLE
Option to store files with a given extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Gmailieer can be configured using `gmi set`. Use without any options to get a li
 
 **`Timeout`** is the timeout in seconds used for the HTTP connection to GMail. `0` means the forever or system error/timeout, [whichever occurs first](https://github.com/gauteh/gmailieer/issues/83#issuecomment-396487919).
 
+**`File extension`** is an optional argument to include the specified extension in local file names (e.g., `mbox`) which can be useful for indexing them with third-party programs. Existing files are not renamed.
+
 **`Drop non existing labels`** can be used to silently ignore errors where GMail gives us a label identifier which is not associated with a label. See [Caveats](#caveats).
 
 **`Replace slash with dot`** is used to replace the sub-label separator (`/`) with a dot (`.`). I think this is easier to work with. *Important*: See note below on [changing this setting after initial sync](#changing-ignored-tags-and-translation-after-initial-sync).

--- a/lieer/gmailieer.py
+++ b/lieer/gmailieer.py
@@ -143,6 +143,9 @@ class Gmailieer:
     parser_set.add_argument ('--ignore-tags-remote', type = str,
         default = None, help = 'Set custom tags to ignore when syncing from remote to local (comma-separated, before translations). Important: see the manual.')
 
+    parser_set.add_argument ('--file-extension', type = str, default = None,
+        help = 'Add a file extension before the maildir status flags (e.g., "mbox")')
+
     parser_set.set_defaults (func = self.set)
 
 
@@ -660,11 +663,15 @@ class Gmailieer:
     if args.ignore_tags_remote is not None:
       self.local.state.set_ignore_remote_labels (args.ignore_tags_remote)
 
+    if args.file_extension is not None:
+      self.local.state.set_file_extension (args.file_extension)
+
     print ("Repository information and settings:")
     print ("Account ...........: %s" % self.local.state.account)
     print ("historyId .........: %d" % self.local.state.last_historyId)
     print ("lastmod ...........: %d" % self.local.state.lastmod)
     print ("Timeout ...........: %f" % self.local.state.timeout)
+    print ("File extension ....: %s" % self.local.state.file_extension)
     print ("Drop non existing labels...:", self.local.state.drop_non_existing_label)
     print ("Replace . with / ..........:", self.local.state.replace_slash_with_dot)
     print ("Ignore tags (local) .......:", self.local.state.ignore_tags)

--- a/lieer/local.py
+++ b/lieer/local.py
@@ -148,8 +148,11 @@ class Local:
       self.write ()
 
     def set_file_extension (self, t):
-      self.file_extension = t.strip ()
-      self.write ()
+      if '.' in t or ':' in t:
+        print('File extensions may not contain the "." or ":" characters!')
+      else:
+        self.file_extension = t.strip ()
+        self.write ()
 
   def __init__ (self, g):
     self.gmailieer = g


### PR DESCRIPTION
Adding file extensions aims to help MacOS users index their synchronized
gmail messages with Spotlight (using https://github.com/tbrk/muttlight).

To use:
    gmi set --file-extension mbox

/!\ This patch assumes that filenames contain a period only if a file
extension has been added using the option.

Addresses #98