### PR TITLE
Set mtime of Maildir message to Gmail internalDate

### DIFF
--- a/lieer/local.py
+++ b/lieer/local.py
@@ -421,6 +421,10 @@ class Local:
       with open (tmp_p, 'wb') as fd:
         fd.write (msg_str)
 
+      # Set atime and mtime of the message file to Gmail receive date
+      internalDate = int(m['internalDate']) / 1000  # ms to s
+      os.utime(tmp_p, (internalDate, internalDate))
+
       os.rename (tmp_p, p)
 
     # add to notmuch


### PR DESCRIPTION
This allows for sorted ls command output and
isync/mbsync use st_mtime when setting IMAP INTERNALDATE